### PR TITLE
Implement typechecking for generic parameters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.4.1"
+          otp-version: "27.1.2"
+          gleam-version: "1.11.1"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ Glimpse is a Gleam library that provides package loading and typechecking capabi
 
 The library is filesystem-agnostic, requiring external module loading through a loader function.
 
+## Code Style
+
+- Never ever add useless comments to the code. Docstrings are good, but comments that just say what the code obviously said should always be avoided.
+
 ## Core Architecture
 
 ### Main Types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ The typechecking uses an `Environment` type that tracks:
 - Main test files are in `test/` directory
 - Typecheck tests are organized in `test/typecheck/` with helper utilities in `helpers.gleam`
 - Test helpers provide utilities for parsing glance modules and validating typecheck results
+- Use `assert actual == expected` syntax instead of gleeunit.should or let assert in unit tests. For example, to verify that a Result containing a string has a certain value, use `assert actual == Ok("hello world")`. This is a new feature introduced in gleam 1.11.
 
 ## Dependencies
 

--- a/src/glimpse/internal/typecheck.gleam
+++ b/src/glimpse/internal/typecheck.gleam
@@ -3,10 +3,11 @@ import gleam/dict
 import gleam/list
 import gleam/option
 import gleam/result
+import gleam/string
 import glimpse/error
 import glimpse/internal/typecheck/functions
 import glimpse/internal/typecheck/types.{
-  type Environment, type TypeResult, type TypeStateResult,
+  type Environment, type Type, type TypeResult, type TypeStateResult,
 }
 
 pub fn block(
@@ -82,7 +83,8 @@ pub fn expression(
     glance.Float(_, _) -> Ok(types.FloatType)
     glance.String(_, _) -> Ok(types.StringType)
     glance.Variable(_, "Nil") -> Ok(types.NilType)
-    glance.Variable(_, "True") | glance.Variable(_, "False") -> Ok(types.BoolType)
+    glance.Variable(_, "True") | glance.Variable(_, "False") ->
+      Ok(types.BoolType)
     glance.Variable(_, name) -> types.lookup_variable_type(environment, name)
 
     glance.NegateInt(_, int_expr) -> {
@@ -163,6 +165,28 @@ pub fn call(
         target_labels,
       )
       |> result.replace(target_return)
+    }
+    types.GenericCallableType(
+      _target_arguments,
+      target_labels,
+      _target_return,
+      original_function,
+    ) -> {
+      let concrete_arg_types =
+        list.map(glimpse_argument_fields, fn(field) {
+          case field {
+            glance.LabelledField(_, type_) -> type_
+            glance.UnlabelledField(type_) -> type_
+            glance.ShorthandField(_) ->
+              panic as "ShorthandField should have been converted by call_field"
+          }
+        })
+
+      typecheck_function_with_concrete_types(
+        environment,
+        original_function,
+        concrete_arg_types,
+      )
     }
     _ -> Error(error.NotCallable(types.to_string(environment, glimpse_target)))
   }
@@ -277,5 +301,54 @@ pub fn binop(
       types.to_binop_error(environment, "<>", left, right, "two Strings")
 
     glance.Pipe, _, _ -> todo as "Pipe binop is not typechecked yet"
+  }
+}
+
+fn typecheck_function_with_concrete_types(
+  environment: Environment,
+  original_function: glance.Function,
+  concrete_arg_types: List(Type),
+) -> error.TypeCheckResult(Type) {
+  let param_count = list.length(original_function.parameters)
+  let arg_count = list.length(concrete_arg_types)
+
+  case param_count == arg_count {
+    False -> {
+      let param_types =
+        list.map(original_function.parameters, fn(param) {
+          case param {
+            glance.FunctionParameter(type_: option.Some(glance_type), ..) ->
+              case types.type_(environment, glance_type) {
+                Ok(type_) -> types.to_string(environment, type_)
+                Error(_) -> "unknown"
+              }
+            _ -> "unknown"
+          }
+        })
+      let arg_type_strings =
+        list.map(concrete_arg_types, types.to_string(environment, _))
+
+      Error(error.InvalidArguments(
+        "(" <> string.join(param_types, ", ") <> ")",
+        "(" <> string.join(arg_type_strings, ", ") <> ")",
+      ))
+    }
+    True -> {
+      use param_env <- result.try(
+        list.zip(original_function.parameters, concrete_arg_types)
+        |> list.fold(Ok(environment), fn(env_result, param_type) {
+          use env <- result.try(env_result)
+          let #(param, concrete_type) = param_type
+          case param {
+            glance.FunctionParameter(name: glance.Named(name), ..) ->
+              Ok(types.add_def_to_env(env, name, concrete_type))
+            _ -> Ok(env)
+          }
+        }),
+      )
+
+      use body_result <- result.try(block(param_env, original_function.body))
+      Ok(body_result.state)
+    }
   }
 }

--- a/src/glimpse/internal/typecheck/functions.gleam
+++ b/src/glimpse/internal/typecheck/functions.gleam
@@ -6,8 +6,8 @@ import gleam/result
 import gleam/string
 import glimpse/error
 import glimpse/internal/typecheck/types.{
-  type EnvState, type EnvStateFold, type EnvStateResult, type Environment,
-  type EnvironmentFold, type EnvironmentResult, type Type,
+  type EnvStateFold, type EnvStateResult, type Environment, type EnvironmentFold,
+  type EnvironmentResult, type Type,
 }
 
 pub type CallableState {
@@ -28,12 +28,41 @@ pub fn empty_state(environment: Environment) -> CallableState {
   CallableState(environment, [], dict.new())
 }
 
+fn has_generic_types(types: List(Type)) -> Bool {
+  list.any(types, is_generic_type)
+}
+
+fn is_generic_type(type_: Type) -> Bool {
+  case type_ {
+    types.GenericTypeVariable(_) -> True
+    _ -> False
+  }
+}
+
 pub fn to_callable_type(state: CallableState, return_type: Type) -> Type {
   types.CallableType(
     state.reversed_by_position |> list.reverse,
     state.labels,
     return_type,
   )
+}
+
+pub fn to_callable_type_with_original(
+  state: CallableState,
+  return_type: Type,
+  original_function: glance.Function,
+) -> Type {
+  let parameters = state.reversed_by_position |> list.reverse
+  case has_generic_types(parameters) || is_generic_type(return_type) {
+    True ->
+      types.GenericCallableType(
+        parameters,
+        state.labels,
+        return_type,
+        original_function,
+      )
+    False -> types.CallableType(parameters, state.labels, return_type)
+  }
 }
 
 type OrderedFoldState {
@@ -73,7 +102,7 @@ pub fn function_signature(
               environment
               |> types.add_def_to_env(
                 function.name,
-                to_callable_type(param_state, return),
+                to_callable_type_with_original(param_state, return, function),
               ),
             )
           }

--- a/src/glimpse/internal/typecheck/types.gleam
+++ b/src/glimpse/internal/typecheck/types.gleam
@@ -10,6 +10,13 @@ import glimpse/error
 /// Placeholder span for synthetic AST nodes created during type inference
 const unknown_span = glance.Span(-1, -1)
 
+fn is_type_variable(name: String) -> Bool {
+  case string.first(name) {
+    Ok(first_char) -> string.lowercase(first_char) == first_char
+    Error(_) -> False
+  }
+}
+
 pub type Type {
   NilType
   IntType
@@ -24,11 +31,21 @@ pub type Type {
     position_labels: Dict(String, Int),
     return: Type,
   )
+  GenericCallableType(
+    /// All parameters (labelled or otherwise)
+    parameters: List(Type),
+    /// Map of label to its position in parameters list
+    position_labels: Dict(String, Int),
+    return: Type,
+    /// Original glance function for re-typechecking
+    original_function: glance.Function,
+  )
   /// Used for field access on imports; no direct glance analog
   NamespaceType(
     definitions: Dict(String, Type),
     custom_types: Dict(String, Type),
   )
+  GenericTypeVariable(name: String)
 }
 
 pub type TypeResult =
@@ -191,7 +208,12 @@ pub fn type_(environment: Environment, glance_type: glance.Type) -> TypeResult {
       }
     }
 
-    glance.VariableType(_, name) -> lookup_variable_type(environment, name)
+    glance.VariableType(_, name) -> {
+      case is_type_variable(name) {
+        True -> Ok(GenericTypeVariable(name))
+        False -> lookup_variable_type(environment, name)
+      }
+    }
     _ -> {
       todo as "many glance types not processed yet"
     }
@@ -207,8 +229,17 @@ pub fn to_string(environment: Environment, type_: Type) -> String {
     BoolType -> "Bool"
     CustomType(module, name) -> module <> "." <> name
     CallableType(parameters, _labels, return) ->
-      "fn (" <> list_to_string(parameters, environment) <> ") -> " <> to_string(environment, return)
+      "fn ("
+      <> list_to_string(parameters, environment)
+      <> ") -> "
+      <> to_string(environment, return)
+    GenericCallableType(parameters, _labels, return, _) ->
+      "fn ("
+      <> list_to_string(parameters, environment)
+      <> ") -> "
+      <> to_string(environment, return)
     NamespaceType(..) -> "<Namespace>"
+    GenericTypeVariable(name) -> name
   }
 }
 
@@ -229,7 +260,8 @@ pub fn to_glance(environment: Environment, type_: Type) -> glance.Type {
       case dict.get(environment.import_names, module) {
         Ok(_relative) if module == environment.current_module ->
           glance.NamedType(unknown_span, name, option.None, [])
-        Ok(relative) -> glance.NamedType(unknown_span, name, option.Some(relative), [])
+        Ok(relative) ->
+          glance.NamedType(unknown_span, name, option.Some(relative), [])
         Error(_) -> panic as "Custom type should always have a valid module"
       }
     }
@@ -239,7 +271,14 @@ pub fn to_glance(environment: Environment, type_: Type) -> glance.Type {
         list.map(parameters, to_glance(environment, _)),
         to_glance(environment, return),
       )
+    GenericCallableType(parameters, _labels, return, _) ->
+      glance.FunctionType(
+        unknown_span,
+        list.map(parameters, to_glance(environment, _)),
+        to_glance(environment, return),
+      )
     NamespaceType(..) -> panic as "Cannot convert namespace to glance"
+    GenericTypeVariable(name) -> glance.VariableType(unknown_span, name)
   }
 }
 

--- a/test/typecheck/assignment_test.gleam
+++ b/test/typecheck/assignment_test.gleam
@@ -4,13 +4,14 @@ import gleeunit/should
 import glimpse/error
 import typecheck/helpers
 
-
 pub fn assign_let_returned_test() {
   let function_out =
     helpers.ok_function_typecheck("fn foo() -> Int { let x = 5 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn assign_let_used_test() {
@@ -22,7 +23,9 @@ pub fn assign_let_used_test() {
     )
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn assign_let_with_type() {
@@ -34,7 +37,9 @@ pub fn assign_let_with_type() {
     )
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn assign_let_with_binop() {
@@ -47,7 +52,9 @@ pub fn assign_let_with_binop() {
     )
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn assign_let_incorrect_type_test() {

--- a/test/typecheck/binops_test.gleam
+++ b/test/typecheck/binops_test.gleam
@@ -7,10 +7,13 @@ import typecheck/helpers
 const unknown_span = glance.Span(-1, -1)
 
 pub fn bool_and_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Bool { True && False }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Bool { True && False }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])),
+  )
 }
 
 pub fn bool_and_invalid_left_test() {
@@ -24,10 +27,13 @@ pub fn bool_and_right_test() {
 }
 
 pub fn bool_or_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Bool { True || False }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Bool { True || False }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])),
+  )
 }
 
 pub fn bool_or_invalid_left_test() {
@@ -41,24 +47,31 @@ pub fn bool_or_right_test() {
 }
 
 pub fn bool_eq_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Bool { True == False }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Bool { True == False }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])),
+  )
 }
 
 pub fn int_eq_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 == 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_eq_infer_return_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() { 1 == 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "Int", option.None, [])),
+  )
 }
 
 pub fn eq_invalid_left_test() {
@@ -75,14 +88,18 @@ pub fn int_neq_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 != 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_neq_infer_return_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() { 1 != 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "Int", option.None, [])),
+  )
 }
 
 pub fn neq_invalid_left_test() {
@@ -99,7 +116,9 @@ pub fn int_less_than_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 < 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_less_than_invalid_left_test() {
@@ -113,10 +132,13 @@ pub fn int_less_than_invalid_right_test() {
 }
 
 pub fn float_less_than_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 1.1 <. 2.2 }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Float { 1.1 <. 2.2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn float_less_than_invalid_left_test() {
@@ -133,7 +155,9 @@ pub fn int_less_than_or_equal_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 <= 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_less_than_or_equal_invalid_left_test() {
@@ -147,10 +171,13 @@ pub fn int_less_than_or_equal_invalid_right_test() {
 }
 
 pub fn float_less_than_or_equal_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 1.1 <=. 2.2 }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Float { 1.1 <=. 2.2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn float_less_than_or_equal_invalid_left_test() {
@@ -167,7 +194,9 @@ pub fn int_greater_than_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 > 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_greater_than_invalid_left_test() {
@@ -181,10 +210,13 @@ pub fn int_greater_than_invalid_right_test() {
 }
 
 pub fn float_greater_than_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 1.1 >. 2.2 }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Float { 1.1 >. 2.2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn float_greater_than_invalid_left_test() {
@@ -196,7 +228,9 @@ pub fn int_greater_than_or_equal_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 >= 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_greater_than_or_equal_invalid_left_test() {
@@ -210,10 +244,13 @@ pub fn int_greater_than_or_equal_invalid_right_test() {
 }
 
 pub fn float_greater_than_or_equal_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 1.1 >=. 2.2 }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Float { 1.1 >=. 2.2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn float_greater_than_or_equal_invalid_left_test() {
@@ -235,7 +272,9 @@ pub fn int_add_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 + 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_add_invalid_left_test() {
@@ -249,10 +288,13 @@ pub fn int_add_invalid_right_test() {
 }
 
 pub fn float_add_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 1.1 +. 2.2 }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Float { 1.1 +. 2.2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn float_add_invalid_left_test() {
@@ -269,7 +311,9 @@ pub fn int_sub_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 - 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_sub_invalid_left_test() {
@@ -283,10 +327,13 @@ pub fn int_sub_invalid_right_test() {
 }
 
 pub fn float_sub_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 1.1 -. 2.2 }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Float { 1.1 -. 2.2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn float_sub_invalid_left_test() {
@@ -303,7 +350,9 @@ pub fn int_mult_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 * 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_mult_invalid_left_test() {
@@ -317,10 +366,13 @@ pub fn int_mult_invalid_right_test() {
 }
 
 pub fn float_mult_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 1.1 *. 2.2 }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Float { 1.1 *. 2.2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn float_mult_invalid_left_test() {
@@ -337,7 +389,9 @@ pub fn int_div_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 / 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_div_invalid_left_test() {
@@ -351,10 +405,13 @@ pub fn int_div_invalid_right_test() {
 }
 
 pub fn float_div_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 1.1 /. 2.2 }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> Float { 1.1 /. 2.2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn float_div_invalid_left_test() {
@@ -371,7 +428,9 @@ pub fn int_remainder_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 1 % 2 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn int_remainder_invalid_left_test() {
@@ -389,7 +448,11 @@ pub fn string_concat_test() {
     helpers.ok_function_typecheck("fn foo() -> String { \"a\" <> \"b\" }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 18), "String", option.None, [])))
+  |> should.equal(
+    option.Some(
+      glance.NamedType(glance.Span(12, 18), "String", option.None, []),
+    ),
+  )
 }
 
 pub fn string_concat_invalid_left_test() {

--- a/test/typecheck/function_call_test.gleam
+++ b/test/typecheck/function_call_test.gleam
@@ -1,3 +1,6 @@
+import glance
+import gleam/list
+import gleam/option
 import gleeunit/should
 import glimpse/error
 import typecheck/assertions
@@ -235,4 +238,74 @@ pub fn shorthand_field_error_if_variable_not_in_scope_test() {
     } ",
   )
   |> should.equal(error.InvalidName("name"))
+}
+
+pub fn generic_identity_function_test() {
+  let #(module, _env) =
+    helpers.ok_module_typecheck(
+      "fn identity(x: a) -> a { x }
+       fn use_identity() -> Int { identity(42) }",
+    )
+
+  echo module
+  assertions.should_have_list_length(module.module.functions, 2)
+}
+
+pub fn generic_function_shorthand_call_test() {
+  let #(module, _env) =
+    helpers.ok_module_typecheck(
+      "fn consume(value x: a) -> a { x }
+       fn use_consume() -> Int {
+         let value = 42
+         consume(value:)
+       }",
+    )
+
+  assert list.length(module.module.functions) == 2
+
+  let assert [use_consume_def, _] = module.module.functions
+  assert use_consume_def.definition.return
+    == option.Some(
+      glance.NamedType(glance.Span(61, 64), "Int", option.None, []),
+    )
+}
+
+pub fn multiple_type_variables_test() {
+  let #(module, _env) =
+    helpers.ok_module_typecheck(
+      "fn first(x: a, y: b) -> a { x }
+       fn use_first() -> Int { first(42, \"hello\") }",
+    )
+
+  assert list.length(module.module.functions) == 2
+
+  let assert [use_first_def, _] = module.module.functions
+  assert use_first_def.definition.return
+    == option.Some(
+      glance.NamedType(glance.Span(57, 60), "Int", option.None, []),
+    )
+}
+
+pub fn mixed_generic_concrete_parameters_test() {
+  let #(module, _env) =
+    helpers.ok_module_typecheck(
+      "fn repeat(value: a, count: Int) -> a { value }
+       fn use_repeat() -> String { repeat(\"hello\", 3) }",
+    )
+
+  assert list.length(module.module.functions) == 2
+
+  let assert [use_repeat_def, _] = module.module.functions
+  assert use_repeat_def.definition.return
+    == option.Some(
+      glance.NamedType(glance.Span(73, 79), "String", option.None, []),
+    )
+}
+
+pub fn generic_function_wrong_arity_test() {
+  helpers.error_module_typecheck(
+    "fn identity(x: a) -> a { x }
+     fn use_identity() -> Int { identity(42, \"extra\") }",
+  )
+  |> should.equal(error.InvalidArguments("(a)", "(Int, String)"))
 }

--- a/test/typecheck/function_params_test.gleam
+++ b/test/typecheck/function_params_test.gleam
@@ -1,4 +1,5 @@
 import glance
+import gleam/dict
 import gleam/option
 import gleeunit/should
 import glimpse/error
@@ -6,13 +7,14 @@ import glimpse/internal/typecheck/types
 import typecheck/assertions
 import typecheck/helpers
 
-
 pub fn int_param_test() {
   let function_out =
     helpers.ok_function_typecheck("fn foo(a: Int) -> Int { a }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(18, 21), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(18, 21), "Int", option.None, [])),
+  )
 }
 
 pub fn int_param_operation_test() {
@@ -20,7 +22,9 @@ pub fn int_param_operation_test() {
     helpers.ok_function_typecheck("fn add(a: Int, b: Int) -> Int { a + b }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(26, 29), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(26, 29), "Int", option.None, [])),
+  )
 }
 
 pub fn float_param_test() {
@@ -28,7 +32,9 @@ pub fn float_param_test() {
     helpers.ok_function_typecheck("fn foo(a: Float) -> Float { a }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(20, 25), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(20, 25), "Float", option.None, [])),
+  )
 }
 
 pub fn string_param_test() {
@@ -36,7 +42,11 @@ pub fn string_param_test() {
     helpers.ok_function_typecheck("fn foo(a: String) -> String { a }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(21, 27), "String", option.None, [])))
+  |> should.equal(
+    option.Some(
+      glance.NamedType(glance.Span(21, 27), "String", option.None, []),
+    ),
+  )
 }
 
 pub fn incorrect_param_return_fails_test() {
@@ -52,7 +62,11 @@ pub fn custom_type_param_test() {
     )
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(27, 33), "MyType", option.None, [])))
+  |> should.equal(
+    option.Some(
+      glance.NamedType(glance.Span(27, 33), "MyType", option.None, []),
+    ),
+  )
 }
 
 pub fn empty_signature_definition_test() {
@@ -128,4 +142,32 @@ pub fn mixed_positional_and_labelled_definition_test() {
     [#("lab", 1)],
     types.NilType,
   )
+}
+
+pub fn generic_function_parameter_test() {
+  let #(_, env) = helpers.ok_module_typecheck("fn consume(x: a) -> Nil { Nil }")
+
+  assertions.should_have_dict_size(env.definitions, 1)
+  assert dict.get(env.definitions, "consume")
+    == Ok(types.GenericCallableType(
+      [types.GenericTypeVariable("a")],
+      dict.new(),
+      types.NilType,
+      glance.Function(
+        glance.Span(0, 31),
+        "consume",
+        glance.Private,
+        [
+          glance.FunctionParameter(
+            option.None,
+            glance.Named("x"),
+            option.Some(glance.VariableType(glance.Span(14, 15), "a")),
+          ),
+        ],
+        option.Some(
+          glance.NamedType(glance.Span(20, 23), "Nil", option.None, []),
+        ),
+        [glance.Expression(glance.Variable(glance.Span(26, 29), "Nil"))],
+      ),
+    ))
 }

--- a/test/typecheck/helpers.gleam
+++ b/test/typecheck/helpers.gleam
@@ -8,7 +8,6 @@ import glimpse/internal/typecheck/types.{type Environment}
 import glimpse/typecheck
 import typecheck/assertions
 
-
 pub fn glance_custom_type(definition: String) -> glance.CustomType {
   let module =
     glance.module(definition)

--- a/test/typecheck/infer_module_test.gleam
+++ b/test/typecheck/infer_module_test.gleam
@@ -18,9 +18,13 @@ pub fn module_with_two_functions_skip() {
   let assert [fun1, fun2] = inferred_module.module.functions
 
   fun1.definition.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "Int", option.None, [])),
+  )
   fun2.definition.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "Int", option.None, [])),
+  )
 }
 
 pub fn proxy_function_error_test() {

--- a/test/typecheck/package_test.gleam
+++ b/test/typecheck/package_test.gleam
@@ -6,7 +6,6 @@ import gleeunit/should
 import typecheck/assertions
 import typecheck/helpers
 
-
 pub fn typecheck_single_module_package_test() {
   let package =
     helpers.ok_package_check("main_module", fn(_) {

--- a/test/typecheck/primitive_types_test.gleam
+++ b/test/typecheck/primitive_types_test.gleam
@@ -10,14 +10,18 @@ pub fn return_nil_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Nil { Nil }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Nil", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Nil", option.None, [])),
+  )
 }
 
 pub fn infer_nil_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() { }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "Nil", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "Nil", option.None, [])),
+  )
 }
 
 pub fn not_nil_error_test() {
@@ -29,14 +33,18 @@ pub fn return_int_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { 5 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn infer_int_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() { 5 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "Int", option.None, [])),
+  )
 }
 
 pub fn not_int_error_test() {
@@ -48,14 +56,18 @@ pub fn return_float_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Float { 5.0 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 17), "Float", option.None, [])),
+  )
 }
 
 pub fn infer_float_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() { 5.0 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "Float", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "Float", option.None, [])),
+  )
 }
 
 pub fn not_float_error_test() {
@@ -64,17 +76,24 @@ pub fn not_float_error_test() {
 }
 
 pub fn return_string_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo() -> String { \"hello\" }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo() -> String { \"hello\" }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 18), "String", option.None, [])))
+  |> should.equal(
+    option.Some(
+      glance.NamedType(glance.Span(12, 18), "String", option.None, []),
+    ),
+  )
 }
 
 pub fn infer_string_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() { \"hello\" }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "String", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "String", option.None, [])),
+  )
 }
 
 pub fn not_string_error_test() {
@@ -86,21 +105,27 @@ pub fn return_true_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Bool { True }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])),
+  )
 }
 
 pub fn return_false_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Bool { False }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])),
+  )
 }
 
 pub fn infer_bool_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() { True }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(unknown_span, "Bool", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(unknown_span, "Bool", option.None, [])),
+  )
 }
 
 pub fn not_bool_error_test() {

--- a/test/typecheck/unops_test.gleam
+++ b/test/typecheck/unops_test.gleam
@@ -4,19 +4,23 @@ import gleeunit/should
 import glimpse/error
 import typecheck/helpers
 
-
 pub fn negate_int_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Int { -5 }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 15), "Int", option.None, [])),
+  )
 }
 
 pub fn negate_int_param_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo(a: Int) -> Int { -a }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo(a: Int) -> Int { -a }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(18, 21), "Int", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(18, 21), "Int", option.None, [])),
+  )
 }
 
 pub fn negate_int_invalid_test() {
@@ -28,14 +32,19 @@ pub fn negate_bool_test() {
   let function_out = helpers.ok_function_typecheck("fn foo() -> Bool { !True }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(12, 16), "Bool", option.None, [])),
+  )
 }
 
 pub fn negate_bool_param_test() {
-  let function_out = helpers.ok_function_typecheck("fn foo(a: Bool) -> Bool { !a }")
+  let function_out =
+    helpers.ok_function_typecheck("fn foo(a: Bool) -> Bool { !a }")
 
   function_out.return
-  |> should.equal(option.Some(glance.NamedType(glance.Span(19, 23), "Bool", option.None, [])))
+  |> should.equal(
+    option.Some(glance.NamedType(glance.Span(19, 23), "Bool", option.None, [])),
+  )
 }
 
 pub fn negate_bool_invalid_test() {


### PR DESCRIPTION
We store the original AST when parameters contain a generic type and
then whenever the function is called we replace the parameters with the
concrete types it was called with and typecheck against that.